### PR TITLE
Remove nav links to G2 and Trustpilot post page deletion

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -72,11 +72,20 @@
     },
     {
       "group": "Knowledge Hub",
-      "pages": ["knowledge-hub/labels", "knowledge-hub/tags", "knowledge-hub/mcp-server"]
+      "pages": [
+        "knowledge-hub/labels",
+        "knowledge-hub/tags",
+        "knowledge-hub/mcp-server"
+      ]
     },
     {
       "group": "Workflows",
-      "pages": ["feedback-search", "email-notifications", "export", "project-management"]
+      "pages": [
+        "feedback-search",
+        "email-notifications",
+        "export",
+        "project-management"
+      ]
     },
     {
       "group": "Social media mentions & reviews",
@@ -84,9 +93,7 @@
         "integrations/apps",
         "integrations/apple",
         "integrations/google",
-        "integrations/reddit",
-        "integrations/g2",
-        "integrations/trustpilot"
+        "integrations/reddit"
       ]
     },
     {
@@ -118,15 +125,28 @@
     },
     {
       "group": "Survey & feedback collection",
-      "pages": ["integrations/delighted", "integrations/survey-monkey", "integrations/typeform", "integrations/sprig"]
+      "pages": [
+        "integrations/delighted",
+        "integrations/survey-monkey",
+        "integrations/typeform",
+        "integrations/sprig"
+      ]
     },
     {
       "group": "Task & project management",
-      "pages": ["integrations/asana", "integrations/jira", "integrations/linear"]
+      "pages": [
+        "integrations/asana",
+        "integrations/jira",
+        "integrations/linear"
+      ]
     },
     {
       "group": "Survey",
-      "pages": ["integrations/qualtrics", "integrations/typeform", "integrations/survey-monkey"]
+      "pages": [
+        "integrations/qualtrics",
+        "integrations/typeform",
+        "integrations/survey-monkey"
+      ]
     },
     {
       "group": "Other Integrations",
@@ -142,7 +162,10 @@
       "pages": [
         {
           "group": "Contacts",
-          "pages": ["api-reference/contacts/identify-contacts", "api-reference/contacts/purge"]
+          "pages": [
+            "api-reference/contacts/identify-contacts",
+            "api-reference/contacts/purge"
+          ]
         },
         {
           "group": "Accounts",
@@ -160,7 +183,12 @@
     },
     {
       "group": "Security",
-      "pages": ["security/security-overview", "security/signin-with-token", "security/team-roles", "security/pii"]
+      "pages": [
+        "security/security-overview",
+        "security/signin-with-token",
+        "security/team-roles",
+        "security/pii"
+      ]
     },
     {
       "group": "SSO",


### PR DESCRIPTION
Pages were removed in another PR. This just removes the links.